### PR TITLE
added cryptofex and syntax files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Heavy:
 
 ## Tooling
 
+* [Cryptofex](https://cryptofex.io) - standalone IDE for Rholang and other smart contracts
 * [rchain.cloud](https://www.rchain.cloud) - run your first few Rholang programs without setting up a node environment
+* [Syntax Files](https://github.com/rchain-community/rholang-syntax-highlighting) - syntax highlighting for emacs and vim
 
 ## Forums / News
 


### PR DESCRIPTION
I added a link for Cryptofex and for vim/emacs syntax files. These were added to the tooling section.

**Other Thought:** 
The description for this repo is much to long. I would recommend cutting it down to one line